### PR TITLE
Fix: Relationships on subquery model.

### DIFF
--- a/src/modelsubquery/functions.py
+++ b/src/modelsubquery/functions.py
@@ -13,7 +13,7 @@ def _model_fields(model, fields):
     then return all the declared fields.
     """
     # TODO: the pk/id field should always be returned
-    declared = {f.column for f in model._meta.get_fields()}
+    declared = {f.column for f in model._meta.get_fields() if f.concrete}
     if fields is None:
         return declared
 

--- a/src/modelsubquery/functions.py
+++ b/src/modelsubquery/functions.py
@@ -13,7 +13,7 @@ def _model_fields(model, fields):
     then return all the declared fields.
     """
     # TODO: the pk/id field should always be returned
-    declared = {f.name for f in model._meta.get_fields()}
+    declared = {f.column for f in model._meta.get_fields()}
     if fields is None:
         return declared
 

--- a/src/modelsubquery/functions.py
+++ b/src/modelsubquery/functions.py
@@ -13,7 +13,7 @@ def _model_fields(model, fields):
     then return all the declared fields.
     """
     # TODO: the pk/id field should always be returned
-    declared = {f.column for f in model._meta.get_fields() if f.concrete}
+    declared = {f.column for f in model._meta.local_concrete_fields}
     if fields is None:
         return declared
 

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from django.db import models
 from django.db.models.functions import ExtractYear
+
 from modelsubquery import ModelSubquery
 
 

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -2,7 +2,6 @@ from datetime import date
 
 from django.db import models
 from django.db.models.functions import ExtractYear
-
 from modelsubquery import ModelSubquery
 
 
@@ -11,6 +10,9 @@ class Book(models.Model):
     rating = models.IntegerField(blank=True, null=True)
     published = models.DateField(default=date.today)
     has_cover = models.BooleanField(default=True)
+    author = models.ForeignKey(
+        "Person", on_delete=models.CASCADE, related_name="books", null=True
+    )
 
 
 class PersonQuerySet(models.QuerySet):

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -31,3 +31,8 @@ class Person(models.Model):
     birth = models.DateField(default=date.today)
 
     objects = PersonQuerySet.as_manager()
+
+
+class Shelve(models.Model):
+    title = models.CharField(max_length=100)
+    books = models.ManyToManyField("Book", related_name="shelves")

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -3,8 +3,21 @@ from datetime import date
 import time_machine
 from django.test import TestCase
 from model_bakery import baker
+from modelsubquery.functions import _model_fields
 
-from .models import Book, Person
+from .models import Book, Person, Shelve
+
+
+class ModelFieldTest(TestCase):
+    def test_model_fields_book(self):
+        fields = _model_fields(Book, None)
+        self.assertEqual(
+            fields, {"id", "title", "author_id", "published", "rating", "has_cover"}
+        )
+
+    def test_model_fields_shelve(self):
+        fields = _model_fields(Shelve, None)
+        self.assertEqual(fields, {"id", "title"})
 
 
 @time_machine.travel("2000-01-01")

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -79,3 +79,16 @@ class DBFunctionTestCase(TestCase):
             self.assertEqual(person.book_of_year.title, "test")
         with self.assertNumQueries(1):
             self.assertEqual(person.book_of_year.rating, 5)
+
+    def test_with_related_field(self):
+        author = baker.make(Person)
+        book = baker.make(Book, author=author)
+
+        # Yes he wrote a book in his birthyear! ;-)
+
+        person = Person.objects.with_book_of_the_year().get()
+        self.assertEqual(person.book_of_year, book)
+
+        # The relation is there, but it's lazy!
+        with self.assertNumQueries(1):
+            self.assertEqual(person.book_of_year.author, author)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -3,6 +3,7 @@ from datetime import date
 import time_machine
 from django.test import TestCase
 from model_bakery import baker
+
 from modelsubquery.functions import _model_fields
 
 from .models import Book, Person, Shelve


### PR DESCRIPTION
It was using the field name instead of the field column which resulted in errors for related fields.

This way other related models work as excepted, but it will issue a query.